### PR TITLE
Fix pom.xml by removing empty starting line.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Most XML readers raises error, if XML signature is not at the very beginning of the file. This causing the build to break at dependency resolving time in case any library is referencing openjsse. (At least with ivy.)

Note this problem effects previous releases as well.